### PR TITLE
✨ [FEAT] 세션 기반 로그인 및 로그아웃 API 구현

### DIFF
--- a/src/main/java/GaVisionUp/server/global/base/ApiResponse.java
+++ b/src/main/java/GaVisionUp/server/global/base/ApiResponse.java
@@ -1,5 +1,6 @@
 package GaVisionUp.server.global.base;
 
+import GaVisionUp.server.global.exception.code.status.GlobalErrorStatus;
 import GaVisionUp.server.global.exception.code.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -28,5 +29,9 @@ public class ApiResponse<T> {
     // 실패한 경우 응답 생성
     public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
         return new ApiResponse<>(false, code, message, data);
+    }
+
+    public static <T> ApiResponse<T> onFailure(GlobalErrorStatus errorStatus, T data) {
+        return new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
     }
 }

--- a/src/main/java/GaVisionUp/server/global/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/GaVisionUp/server/global/exception/code/status/GlobalErrorStatus.java
@@ -24,8 +24,14 @@ public enum GlobalErrorStatus implements ApiErrorCodeInterface {
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다."),
 
     // User Error Status
-    _INVALID_DEPARTMENT(HttpStatus.BAD_REQUEST, "USER4001", "잘못된 소속입니다."),
-    _INVALID_ROLE(HttpStatus.BAD_REQUEST, "USER4002", "잘못된 권한입니다.")
+    _USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 사원입니다."),
+    _INVALID_USER(HttpStatus.BAD_REQUEST, "USER4002", "일치하지 않는 유저입니다."),
+    _INVALID_DEPARTMENT(HttpStatus.BAD_REQUEST, "USER4003", "잘못된 소속입니다."),
+    _INVALID_ROLE(HttpStatus.BAD_REQUEST, "USER4004", "잘못된 권한입니다."),
+    _ID_WRONG(HttpStatus.BAD_REQUEST, "USER4005", "잘못된 아이디입니다."),
+    _PW_WRONG(HttpStatus.BAD_REQUEST, "USER4006", "비밀번호가 틀렸습니다."),
+    _NOT_LOGIN(HttpStatus.UNAUTHORIZED, "USER4007", "로그인 되지 않은 사용자입니다."),
+    _NOT_FOUND_INFORMATION(HttpStatus.NOT_FOUND, "USER4008", "사용자 정보를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/GaVisionUp/server/repository/user/UserRepository.java
+++ b/src/main/java/GaVisionUp/server/repository/user/UserRepository.java
@@ -11,5 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByLoginIdAndPassword(String loginId, String password);
     Optional<User> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
 }
 

--- a/src/main/java/GaVisionUp/server/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/GaVisionUp/server/service/user/UserCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package GaVisionUp.server.service.user;
 
 import GaVisionUp.server.entity.User;
+import GaVisionUp.server.global.exception.RestApiException;
+import GaVisionUp.server.global.exception.code.status.GlobalErrorStatus;
 import GaVisionUp.server.repository.user.UserRepository;
 import GaVisionUp.server.web.dto.UserRequest;
 import GaVisionUp.server.web.dto.UserResponse;
@@ -21,7 +23,7 @@ public class UserCommandServiceImpl implements UserCommandService{
     @Override
     public UserResponse.UpdateInformation updateInformation(Long userId, UserRequest.Update request) {
         User user = userRepository.findById(userId).
-                orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사원입니다."));
+                orElseThrow(() -> new RestApiException(GlobalErrorStatus._USER_NOT_EXIST));
 
         String changedImageUrl = user.getProfileImageUrl();
 

--- a/src/main/java/GaVisionUp/server/service/user/UserQueryService.java
+++ b/src/main/java/GaVisionUp/server/service/user/UserQueryService.java
@@ -1,8 +1,15 @@
 package GaVisionUp.server.service.user;
 
+import GaVisionUp.server.entity.User;
+import GaVisionUp.server.web.dto.UserRequest;
 import GaVisionUp.server.web.dto.UserResponse;
+
+import java.util.Optional;
 
 public interface UserQueryService {
 
+    User login(UserRequest.Login request);
+
     UserResponse.Information getUserInformation(Long userId);
+
 }

--- a/src/main/java/GaVisionUp/server/service/user/UserQueryServiceImpl.java
+++ b/src/main/java/GaVisionUp/server/service/user/UserQueryServiceImpl.java
@@ -1,12 +1,17 @@
 package GaVisionUp.server.service.user;
 
 import GaVisionUp.server.entity.User;
+import GaVisionUp.server.global.exception.RestApiException;
+import GaVisionUp.server.global.exception.code.status.GlobalErrorStatus;
 import GaVisionUp.server.repository.user.UserRepository;
+import GaVisionUp.server.web.dto.UserRequest;
 import GaVisionUp.server.web.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 
 @Service
@@ -18,6 +23,35 @@ public class UserQueryServiceImpl implements UserQueryService{
 
     @Value("${server.url}") // 서버 URL (예: http://localhost:8080)
     private String serverUrl;
+
+
+    /**
+     *  로그인 기능
+     *  화면에서 LoginRequest(loginId, password)을 입력받아 loginId와 password가 일치하면 User return
+     *  loginId가 존재하지 않거나 password가 일치하지 않으면 예외 던짐
+     */
+    public User login(UserRequest.Login request) {
+        Optional<User> optionalUser = userRepository.findByLoginId(request.getLoginId());
+
+        // loginId와 일치하는 User가 없으면 null return
+        if(optionalUser.isEmpty()) {
+            throw new RestApiException(GlobalErrorStatus._ID_WRONG);
+        }
+
+        User user = optionalUser.get();
+
+        // 찾아온 User의 password와 입력된 password가 다르면 null return
+        String userPassword = user.getChangedPW();
+        if (userPassword == null || userPassword.isEmpty()) {
+            userPassword = user.getPassword();
+        }
+
+        if(!userPassword.equals(request.getPassword())) {
+            throw new RestApiException(GlobalErrorStatus._PW_WRONG);
+        }
+
+        return user;
+    }
 
     @Override
     public UserResponse.Information getUserInformation(Long userId) {

--- a/src/main/java/GaVisionUp/server/web/controller/user/UserController.java
+++ b/src/main/java/GaVisionUp/server/web/controller/user/UserController.java
@@ -1,14 +1,23 @@
 package GaVisionUp.server.web.controller.user;
 
-import GaVisionUp.server.entity.exp.ExpBar;
+import GaVisionUp.server.entity.User;
 import GaVisionUp.server.global.base.ApiResponse;
+import GaVisionUp.server.global.exception.code.status.GlobalErrorStatus;
 import GaVisionUp.server.service.user.UserCommandService;
 import GaVisionUp.server.service.user.UserQueryService;
 import GaVisionUp.server.web.dto.UserRequest;
 import GaVisionUp.server.web.dto.UserResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,16 +27,84 @@ public class UserController {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
-    @GetMapping("/{userId}/information")
+    @PostMapping("/login")
+    public ApiResponse<UserResponse.Login> login(@RequestBody UserRequest.Login request, HttpServletRequest httpServletRequest) {
+        // 사용자 인증 로직
+        User user = userQueryService.login(request);
+
+        // 로그인 성공 시 세션 생성
+        httpServletRequest.getSession().invalidate();
+        HttpSession session = httpServletRequest.getSession(true);
+        session.setAttribute("userId", user.getId());
+        session.setMaxInactiveInterval(1800); // 30분 유지
+
+        sessionList.put(session.getId(), session);
+
+        // 성공 응답 반환
+        return ApiResponse.onSuccess(UserResponse.Login.builder().user(user).build());
+    }
+
+    @GetMapping("/logout")
+    public ApiResponse<?> logout(HttpServletRequest request, Model model) {
+        HttpSession session = request.getSession(false); // 세션이 없으면 null 반환
+        if (session != null) {
+            sessionList.remove(session.getId());
+            session.invalidate(); // 세션 무효화
+        }
+
+
+        // 성공 응답 반환
+        return ApiResponse.onSuccess("로그아웃 성공!");
+    }
+
+    @GetMapping("/info")
     public ApiResponse<UserResponse.Information> getUserInformation(
-            @PathVariable Long userId) {
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = false) Long sessionUserId,
+            @RequestParam(name = "userId", required = false) Long userId) {
+        // 세션에서 userId가 없는 경우 (로그인하지 않은 상태)
+        if (sessionUserId == null) {
+            return ApiResponse.onFailure(GlobalErrorStatus._NOT_LOGIN, null);
+        }
+
+        // 요청으로 전달된 userId와 세션의 userId가 다를 경우 에러 반환
+        if (userId != null && !sessionUserId.equals(userId)) {
+            return ApiResponse.onFailure(GlobalErrorStatus._INVALID_USER, null);
+        }
+
+        // 성공적으로 사용자 정보를 반환
         return ApiResponse.onSuccess(userQueryService.getUserInformation(userId));
     }
 
-    @PutMapping("/{userId}/information")
+    @PutMapping("/info")
     public ApiResponse<UserResponse.UpdateInformation> updateInformation(
-            @PathVariable Long userId,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = false) Long sessionUserId,
+            @RequestParam(name = "userId", required = false) Long userId,
             @RequestBody UserRequest.Update request){
+
+        // 세션에서 userId가 없는 경우 (로그인하지 않은 상태)
+        if (sessionUserId == null) {
+            return ApiResponse.onFailure(GlobalErrorStatus._NOT_LOGIN, null);
+        }
+
+        // 요청으로 전달된 userId와 세션의 userId가 다를 경우 에러 반환
+        if (userId != null && !sessionUserId.equals(userId)) {
+            return ApiResponse.onFailure(GlobalErrorStatus._INVALID_USER, null);
+        }
+
         return ApiResponse.onSuccess(userCommandService.updateInformation(userId, request));
+    }
+
+    public static Hashtable sessionList = new Hashtable();
+
+    @GetMapping("/session-list")
+    @ResponseBody
+    public Map<String, String> sessionList() {
+        Enumeration elements = sessionList.elements();
+        Map<String, String> lists = new HashMap<>();
+        while(elements.hasMoreElements()) {
+            HttpSession session = (HttpSession)elements.nextElement();
+            lists.put(session.getId(), String.valueOf(session.getAttribute("userId")));
+        }
+        return lists;
     }
 }

--- a/src/main/java/GaVisionUp/server/web/dto/UserRequest.java
+++ b/src/main/java/GaVisionUp/server/web/dto/UserRequest.java
@@ -10,6 +10,23 @@ import lombok.NoArgsConstructor;
 
 public class UserRequest {
 
+    @Schema(description = "로그인 DTO")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Login {
+
+        @Schema(description = "로그인 id")
+        @NotNull
+        @Size(max = 20, message = "아이디는 20자 이내로 입력해주세요.")
+        private String loginId;
+
+        @Schema(description = "로그인 pw")
+        @Size(max = 10, message = "비밀번호는 10자 이내로 입력해주세요.")
+        private String password;
+    }
+
     @Schema(description = "정보 수정 DTO")
     @Getter
     @NoArgsConstructor

--- a/src/main/java/GaVisionUp/server/web/dto/UserResponse.java
+++ b/src/main/java/GaVisionUp/server/web/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package GaVisionUp.server.web.dto;
 
+import GaVisionUp.server.entity.User;
 import GaVisionUp.server.entity.enums.Department;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,13 @@ import lombok.Setter;
 import java.time.LocalDate;
 
 public class UserResponse {
+
+    @Getter
+    @Setter
+    @Builder
+    public static class Login{
+        User user;
+    }
 
     @Getter
     @Setter


### PR DESCRIPTION
## 📚 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #1 - 로그인 및 로그아웃 API 구현

## ✔ 작업 사항
- 로그인 API 구현
- 로그아웃 API 구현
## 🔧 기타
- 일단 세션 기반으로 로그인 및 로그아웃 API 구현했고, 추후 보안 관련해서 수정 있을 예정

## 💻 테스트 결과
### 아직 로그인 안했을 때
![image](https://github.com/user-attachments/assets/7a3472fc-f7c5-445b-bab7-b7c85726dece)
### 로그인 API 성공
![image](https://github.com/user-attachments/assets/9db7854e-d356-4f44-9dbf-3492f37892ff)
![image](https://github.com/user-attachments/assets/0a9dbe7f-30a8-4d5b-a8e0-bc6c1279fda3)
![image](https://github.com/user-attachments/assets/6431b50a-4a94-4591-a6df-7c11e6953217)

### 로그인 한 유저만 정보 조회 할 수 있게 구현
![image](https://github.com/user-attachments/assets/9cf19813-326c-4539-86ec-3f27e0df7c55)
![image](https://github.com/user-attachments/assets/a977046a-0970-4c94-b3c8-3f977c86aade)
### 로그아웃 API 성공
![image](https://github.com/user-attachments/assets/32b80cf5-5449-4ccd-be82-82fd6ee16b63)
![image](https://github.com/user-attachments/assets/b6cca9bd-4c87-4312-8de5-be558646235e)
